### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Inspired by [js-must-watch](https://github.com/bolshchikov/js-must-watch). Creat
 
 ## 2015
 * Raymond Hettinger: **Beyond PEP 8 -- Best practices for beautiful intelligible code** (PyCon US)
+    * [PyCon presentation](https://us.pycon.org/2015/schedule/presentation/416/)
     * Video: [youtube](https://www.youtube.com/watch?v=wf-BqAjZb8M)
 
 * David Beazley: **Python Concurrency From the Ground Up: LIVE!** (PyCon US)

--- a/README.md
+++ b/README.md
@@ -125,3 +125,8 @@ Inspired by [js-must-watch](https://github.com/bolshchikov/js-must-watch). Creat
 
 * David Beazley: **Python Concurrency From the Ground Up: LIVE!** (PyCon US)
     * Video: [youtube](https://www.youtube.com/watch?v=MCs5OvhV9S4)
+
+* Ned Batchelder: **Facts and Myths about Python names and values** (PyCon US)
+    * [PyCon presentation](https://us.pycon.org/2015/schedule/presentation/362/)
+    * Video: [youtube](https://www.youtube.com/watch?v=_AEJHKGk9ns)/[pyvideo](http://pyvideo.org/video/3466/facts-and-myths-about-python-names-and-values)
+    * [Slides and new article](http://nedbatchelder.com/text/names1.html)/[Original article](http://nedbatchelder.com/text/names.html)

--- a/videos.json
+++ b/videos.json
@@ -392,5 +392,18 @@
       "youtube": "https://www.youtube.com/watch?v=2wDvzy6Hgxg"
     },
     "tags": ["type", "python3"]
-  }  
+  },
+  {
+    "title": "Facts and Myths about Python names and values",
+    "presenter": "Ned Batchelder",
+    "year": 2015,
+    "venue": "PyCon Montreal",
+    "presentation": "https://us.pycon.org/2015/schedule/presentation/362/",
+    "slides": "http://nedbatchelder.com/text/names1.html",
+    "videos": {
+      "youtube": "https://www.youtube.com/watch?v=_AEJHKGk9ns",
+      "pyvideo": "http://pyvideo.org/video/3466/facts-and-myths-about-python-names-and-values",
+    },
+    "tags": ["novice", "core"],
+  }
 ]

--- a/videos.json
+++ b/videos.json
@@ -130,7 +130,7 @@
       "youtube": "https://www.youtube.com/watch?v=e08kOj2kISU"
     },
     "tags": ["optimization", "performance"]
-  },  
+  },
   {
     "title": "Python 3 Metaprogramming",
     "presenter": "David Beazley",
@@ -341,10 +341,10 @@
     "title": "Getting Started Testing",
     "presenter": "Ned Batchelder",
     "year": 2014,
-    "venue": "PyCon US", 
+    "venue": "PyCon US",
     "presentation": "https://us.pycon.org/2014/schedule/presentation/150/",
     "slides": "https://speakerdeck.com/pycon2014/getting-started-testing-by-ned-batchelder",
-    "videos": { 
+    "videos": {
       "youtube": "https://www.youtube.com/watch?v=FxSsnHeWQBY",
       "pyvideo": "http://pyvideo.org/video/2674/getting-started-testing"
     },

--- a/videos.json
+++ b/videos.json
@@ -367,6 +367,7 @@
     "presenter": "Raymond Hettinger",
     "year": 2015,
     "venue": "PyCon Montreal",
+    "presentation": "https://us.pycon.org/2015/schedule/presentation/416/",
     "videos": {
       "youtube": "https://www.youtube.com/watch?v=wf-BqAjZb8M"
     },


### PR DESCRIPTION
Add presentation link for "Beyond PEP 8..." #46
Add "Facts and myths about Python names and values" #46
Remove trailing whitespaces