### PR TITLE
Fixing filename on error

### DIFF
--- a/add_youtube_durations.py
+++ b/add_youtube_durations.py
@@ -7,7 +7,7 @@ def load_youtube_api_key():
     try:
         return open('youtube_api_key.txt', 'r').read().strip()
     except:
-        print('Add file called youtube_ api.txt and insert a youtube api key.')
+        print('Add file called youtube_api_key.txt and insert a youtube api key.')
         print('Youtube api key can be obtained at: https://console.developers.google.com.')
         exit(0)
 


### PR DESCRIPTION
Fix the name of the file on the error message to: youtube_api_key.txt